### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
  1. Go to *Settings -> Editor -> Log highlighting (Ideolog)*.
  2. Add new *Log format* (plus sign on the right of the top list).
  3. Put a name *Symfony* or whatever suits You.
- 4. In the field *Message pattern* place this regex: `^\[((?:\d{4}-\d{2}-\d{2})[\sT]\d{2}:\d{2}:\d{2})(?:\.\d+\+\d{2}:\d{2})?\]\s+([^.]+)\.([^:]+):\s+(.*)$`
+ 4. In the field *Message pattern* place this regex: `^\[((?:\d{4}-\d{2}-\d{2})[\sT]\d{2}:\d{2}:\d{2})(?:\.\d+[\+-]\d{2}:\d{2})?\]\s+([^.]+)\.([^:]+):\s+(.*)$`
  5. In the field *Message start pattern* put this regex: `^\[`.
  6. In the field *Time format* put this pattern: `yyyy-MM-dd.HH:mm:ss`.
  7. In the field *Time capture group* set number **1**.


### PR DESCRIPTION
The pattern for the time doesn't work if the timezone offset from UTC is negative - so not recognised for me here in Canada.
The small fix presented allows either + or - timezone offset, and with this small change the logs are now corectly parsed for me.